### PR TITLE
Style Docs updates

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -208,7 +208,7 @@ The following naming conventions *SHOULD* be used:
 	let myString = new String(something);
 	```
 
-1. When passing an anonymour function as an argument, arrow functions *SHOULD*
+1. When passing an anonymous function as an argument, arrow functions *SHOULD*
 	be used. Implicit returns from arrow functions are allowed if they increase the code readability and the return
 	value is not ignored:
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -208,7 +208,7 @@ The following naming conventions *SHOULD* be used:
 	let myString = new String(something);
 	```
 
-1. When using a *literal function*, an anonymous function that is being passed as an argument, arrow functions *SHOULD*
+1. When passing an anonymour function as an argument, arrow functions *SHOULD*
 	be used. Implicit returns from arrow functions are allowed if they increase the code readability and the return
 	value is not ignored:
 
@@ -226,7 +226,7 @@ The following naming conventions *SHOULD* be used:
 	[ 1, 2, 3 ].forEach((value) => console.log(value));
 	```
 
-1. When functions are not *literal functions*, arrow functions *SHOULD NOT* be used:
+1. When functions are not anonymous arguments to a function, arrow functions *SHOULD NOT* be used:
 
 	```ts
 	// correct


### PR DESCRIPTION
To quote the wikipedia page on Literals(a very reputable source obviously),
>An anonymous function is a literal for the function type.

And from JavaScript the good parts:

>A function literal has four parts.
>
>The first part is the reserved word function.
>
>The optional second part is the function's name. The function can use its name to call itself recursively. The name can also be used by debuggers and development tools to identify the function. If a function is not given a name, as shown in the previous example, it is said to be anonymous.
>
>The third part is the set of parameters of the function, wrapped in parentheses. Within the parentheses is a set of zero or more parameter names, separated by commas. These names will be defined as variables in the function. Unlike ordinary variables, instead of being initialized to undefined, they will be initialized to the arguments supplied when the function is invoked.
>
>The fourth part is a set of statements wrapped in curly braces. These statements are the body of the function. They are executed when the function is invoked.
>
>A function literal can appear anywhere that an expression can appear...

So when we say
> When using a *literal function*, an anonymous function that is being passed as an argument,

I interpret that as 
>When using a *literal function*, a literal function that is being passed as an argument,

This change just removes that wording.